### PR TITLE
feat: add conventional commits title convention to PR prompt

### DIFF
--- a/ai_pr/models.py
+++ b/ai_pr/models.py
@@ -31,7 +31,11 @@ def get_ai_review(diff, branch_name, commits, target_branch, diff_stat):
     diff_limit = config.get("diff_limit", "-1")
 
     try:
-        limit = int(diff_limit) if diff_limit and str(diff_limit).strip('-').isdigit() else -1
+        limit = (
+            int(diff_limit)
+            if diff_limit and str(diff_limit).strip("-").isdigit()
+            else -1
+        )
     except ValueError:
         limit = -1
 
@@ -52,6 +56,7 @@ def get_ai_review(diff, branch_name, commits, target_branch, diff_stat):
         f"- Recent commits:\n{commits}\n\n"
         f"- File Change Summary:\n{diff_stat}\n\n"
         f"Task: Review the git diff below and write a PR title and description. "
+        f"TITLE CONVENTION: Use conventional commits for the title (e.g., feat: [title], fix: [title], docs: [title]).\n\n"
         f"Use the commit history to understand the intent behind the changes.\n\n"
         f"{extra_prompt}"
         f"IMPORTANT: Do not include any signatures, footers, or mentions of "


### PR DESCRIPTION
## Summary
- Add instruction to the AI review prompt requesting conventional commit format for PR titles (e.g., `feat:`, `fix:`, `docs:`)
- Reformat the `diff_limit` parsing expression for improved readability

## Test plan
- [ ] Verify generated PR titles follow conventional commit format after this change
- [ ] Confirm diff limit parsing still works correctly with the reformatted code