### PR TITLE
feat(config): Introduce strict AI provider validation and refactor configuration handling

### DIFF
--- a/floyd/adapters/outbound/config/toml_config_adapter.py
+++ b/floyd/adapters/outbound/config/toml_config_adapter.py
@@ -6,6 +6,11 @@ from pathlib import Path
 
 from floyd.application.dto.ai_config import AIConfig
 from floyd.application.ports.outbound.config_port import ConfigPort
+from floyd.domain.exceptions.ai.invalid_provider_exception import InvalidProviderException
+from floyd.domain.exceptions.config.invalid_config_exception import (
+    InvalidConfigException,
+)
+from floyd.domain.value_objects.ai_provider import AIProvider
 
 
 class TomlConfigAdapter(ConfigPort):
@@ -40,7 +45,10 @@ class TomlConfigAdapter(ConfigPort):
             AIConfig with settings from file or defaults.
         """
         if not self._config_path.exists():
-            return AIConfig()
+            raise InvalidConfigException(
+                f"Configuration file not found at {self._config_path}. "
+                "Please create it or check the path."
+            )
 
         try:
             with open(self._config_path, "rb") as f:
@@ -48,10 +56,14 @@ class TomlConfigAdapter(ConfigPort):
 
             ai_section = data.get("ai", {})
 
-            provider = str(ai_section.get("provider", "claude")).lower().strip()
+            raw_provider = str(ai_section.get("provider")).lower().strip()
+
+            provider = AIProvider(name=raw_provider)
 
             diff_limit_raw = ai_section.get("diff_limit")
+
             diff_limit = -1
+
             if diff_limit_raw is not None:
                 try:
                     diff_limit = int(diff_limit_raw)
@@ -61,8 +73,12 @@ class TomlConfigAdapter(ConfigPort):
             instructions = str(ai_section.get("instructions") or "").strip()
 
             return AIConfig(
-                provider=provider, diff_limit=diff_limit, instructions=instructions
+                provider=provider.type, diff_limit=diff_limit, instructions=instructions
             )
 
-        except Exception:
-            return AIConfig()
+        except InvalidProviderException as e:
+            raise e
+        except tomllib.TOMLDecodeError as e:
+            raise InvalidConfigException(f"Failed to parse TOML file: {str(e)}")
+        except Exception as e:
+            raise InvalidConfigException(f"Configuration error: {str(e)}")

--- a/floyd/application/dto/ai_config.py
+++ b/floyd/application/dto/ai_config.py
@@ -2,12 +2,13 @@
 
 from pydantic import BaseModel, Field
 
+from floyd.domain.value_objects.ai_provider import ProviderType
+
 
 class AIConfig(BaseModel):
     """Configuration for AI service."""
 
-    provider: str = Field(
-        default="claude",
+    provider: ProviderType = Field(
         description="The AI provider to use (e.g., 'claude', 'gemini', 'copilot')."
     )
 

--- a/floyd/domain/exceptions/__init__.py
+++ b/floyd/domain/exceptions/__init__.py
@@ -1,5 +1,9 @@
 """Domain exceptions."""
 
+from floyd.domain.exceptions.ai.invalid_provider_exception import InvalidProviderException
+from floyd.domain.exceptions.config.invalid_config_exception import (
+    InvalidConfigException,
+)
 from floyd.domain.exceptions.domain_exception import DomainException
 from floyd.domain.exceptions.git.branch_not_found_exception import (
     BranchNotFoundException,
@@ -16,4 +20,6 @@ __all__ = [
     "InvalidBranchException",
     "PRAlreadyExistsException",
     "PRGenerationException",
+    "InvalidConfigException",
+    "InvalidProviderException",
 ]

--- a/floyd/domain/exceptions/ai/invalid_provider_exception.py
+++ b/floyd/domain/exceptions/ai/invalid_provider_exception.py
@@ -1,0 +1,6 @@
+from floyd.domain.exceptions.domain_exception import DomainException
+
+
+class InvalidProviderException(DomainException):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/floyd/domain/exceptions/config/invalid_config_exception.py
+++ b/floyd/domain/exceptions/config/invalid_config_exception.py
@@ -1,0 +1,6 @@
+from floyd.domain.exceptions.domain_exception import DomainException
+
+
+class InvalidConfigException(DomainException):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/floyd/domain/value_objects/ai_provider.py
+++ b/floyd/domain/value_objects/ai_provider.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+from pydantic import BaseModel, field_validator
+
+from floyd.domain.exceptions.ai.invalid_provider_exception import (
+    InvalidProviderException,
+)
+
+
+class ProviderType(str, Enum):
+    CLAUDE = "claude"
+    GEMINI = "gemini"
+
+
+class AIProvider(BaseModel):
+    name: str
+
+    model_config = {"frozen": True}
+
+    @property
+    def type(self) -> ProviderType:
+        return ProviderType(self.name)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        v = v.strip().lower()
+
+        try:
+            ProviderType(v)
+
+            return v
+        except ValueError:
+            valid = [p.value for p in ProviderType]
+
+            raise InvalidProviderException(
+                f"Unsupported provider '{v}'. Supported: {', '.join(valid)}"
+            )
+
+    def is_claude(self) -> bool:
+        return self.name == ProviderType.CLAUDE.value
+
+    def is_gemini(self) -> bool:
+        return self.name == ProviderType.GEMINI.value
+
+    def __str__(self) -> str:
+        return self.name


### PR DESCRIPTION
This pull request enhances the AI provider configuration by introducing a more robust, type-safe, and explicit system. The changes eliminate silent fallbacks to default providers and improve error handling for configuration issues.

Key changes include:

- **AIProvider Value Object**: Replaced the string-based provider with a new `AIProvider` value object and a `ProviderType` enum (`claude`, `gemini`). This ensures type safety and centralizes validation logic.
- **Strict Validation**: The application now validates the `provider` field in the configuration file against the supported `ProviderType` enum. An unsupported or missing provider will raise an `InvalidProviderException` with a clear error message.
- **Improved Exception Handling**:
    - Introduced `InvalidProviderException` for unsupported AI providers.
    - Added `InvalidConfigException` to provide clearer errors for issues like a missing configuration file or TOML parsing errors.
- **Extensible Adapter Mapping**: Refactored the AI service selection logic in the dependency injection container to use a dictionary map. This makes it easier to register and use new AI provider adapters in the future.