### PR TITLE
feat(errors): introduce specific exceptions for terminal commands

### DIFF
--- a/floyd/adapters/outbound/utils/terminal.py
+++ b/floyd/adapters/outbound/utils/terminal.py
@@ -2,7 +2,10 @@ import subprocess
 from rich.console import Console
 import shlex
 
-from floyd.domain.exceptions.pr.pr_generation_exception import PRGenerationException
+from floyd.domain.exceptions.terminal.missing_dependency_exception import (
+    MissingDependencyException,
+)
+from floyd.domain.exceptions.terminal.unexpected_exception import UnexpectedException
 
 
 class Terminal:
@@ -21,8 +24,6 @@ class Terminal:
         except subprocess.CalledProcessError as e:
             detail = e.stderr.strip() or str(e)
 
-            raise PRGenerationException(f"{error_msg}: {detail}") from None
+            raise UnexpectedException(f"{error_msg}: {detail}") from None
         except FileNotFoundError:
-            raise PRGenerationException(
-                f"The tool '{cmd_list[0]}' was not found. Please ensure it is installed."
-            )
+            raise MissingDependencyException(cmd_list[0])

--- a/floyd/domain/exceptions/__init__.py
+++ b/floyd/domain/exceptions/__init__.py
@@ -1,6 +1,8 @@
 """Domain exceptions."""
 
-from floyd.domain.exceptions.ai.invalid_provider_exception import InvalidProviderException
+from floyd.domain.exceptions.ai.invalid_provider_exception import (
+    InvalidProviderException,
+)
 from floyd.domain.exceptions.config.invalid_config_exception import (
     InvalidConfigException,
 )
@@ -13,6 +15,10 @@ from floyd.domain.exceptions.pr.pr_already_exist_exception import (
     PRAlreadyExistsException,
 )
 from floyd.domain.exceptions.pr.pr_generation_exception import PRGenerationException
+from floyd.domain.exceptions.terminal.missing_dependency_exception import (
+    MissingDependencyException,
+)
+from floyd.domain.exceptions.terminal.unexpected_exception import UnexpectedException
 
 __all__ = [
     "BranchNotFoundException",
@@ -22,4 +28,6 @@ __all__ = [
     "PRGenerationException",
     "InvalidConfigException",
     "InvalidProviderException",
+    "MissingDependencyException",
+    "UnexpectedException",
 ]

--- a/floyd/domain/exceptions/ai/__init__.py
+++ b/floyd/domain/exceptions/ai/__init__.py
@@ -1,0 +1,6 @@
+from floyd.domain.exceptions.terminal.missing_dependency_exception import (
+    MissingDependencyException,
+)
+from floyd.domain.exceptions.terminal.unexpected_exception import UnexpectedException
+
+__all__ = ["MissingDependencyException", "UnexpectedException"]

--- a/floyd/domain/exceptions/config/__init__.py
+++ b/floyd/domain/exceptions/config/__init__.py
@@ -1,0 +1,3 @@
+from floyd.domain.exceptions.config.invalid_config_exception import InvalidConfigException
+
+__all__ = ["InvalidConfigException"]

--- a/floyd/domain/exceptions/terminal/missing_dependency_exception.py
+++ b/floyd/domain/exceptions/terminal/missing_dependency_exception.py
@@ -1,0 +1,7 @@
+from floyd.domain.exceptions.domain_exception import DomainException
+
+
+class MissingDependencyException(DomainException):
+    def __init__(self, tool_name: str) -> None:
+        super().__init__(f"The tool '{tool_name}' was not found. Please ensure it is installed.")
+        self.tool_name = tool_name

--- a/floyd/domain/exceptions/terminal/unexpected_exception.py
+++ b/floyd/domain/exceptions/terminal/unexpected_exception.py
@@ -1,0 +1,6 @@
+from floyd.domain.exceptions.domain_exception import DomainException
+
+
+class UnexpectedException(DomainException):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)


### PR DESCRIPTION
This commit refactors the error handling within the `Terminal` adapter by replacing the generic `PRGenerationException` with more specific, descriptive exceptions.

The following changes were made:
- Introduced `MissingDependencyException` to be raised when a command-line tool is not found.
- Introduced `UnexpectedException` to handle other unexpected subprocess errors.

This provides more granular error handling, making it easier to debug issues related to missing dependencies versus other runtime command failures.